### PR TITLE
Fix code scanning alert no. 44: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -200,7 +200,8 @@ def get_user_profile(user_id: str):
         else:
             return Response(response=json.dumps(user_profile.to_item()), status=200)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        app.logger.error(f"Error in get_user_profile: {e}")
+        return Response(response="An internal error has occurred.", status=500)
 
 @app.route('/user-profiles', methods=['GET'])
 def get_all_user_profiles():
@@ -209,7 +210,8 @@ def get_all_user_profiles():
         json_user_profiles = [user_profile.to_item() for user_profile in user_profiles]
         return Response(response=json.dumps(json_user_profiles), status=200)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        app.logger.error(f"Error in get_all_user_profiles: {e}")
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/user-groups/<group_id>', methods=['POST'])
 def create_user_group(group_id: str):
@@ -233,7 +235,8 @@ def create_user_group(group_id: str):
     except CosmosConflictError as e:
         return Response(response=str(e), status=409)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        app.logger.error(f"Error in create_user_group: {e}")
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/user-groups/<group_id>', methods=['GET'])
 def get_user_group(group_id: str):


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/44](https://github.com/arpitjain099/openai/security/code-scanning/44)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach maintains the ability to debug issues using server logs while protecting sensitive information from being exposed.

**Steps to fix:**
1. Replace the `str(e)` in the response with a generic error message.
2. Log the detailed exception information using the application's logging mechanism.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
