### PR TITLE
Fix code scanning alert no. 49: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -244,7 +244,8 @@ def get_user_group(group_id: str):
         else:
             return Response(response=json.dumps(user_group.to_item()), status=200)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        logging.error("An error occurred while fetching user group: %s", e, exc_info=True)
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/user-groups/user/<user_id>', methods=['GET'])
 def get_user_member_groups(user_id: str):
@@ -255,7 +256,8 @@ def get_user_member_groups(user_id: str):
         else:
             return Response(response=json.dumps([user_group.to_item_no_users() for user_group in user_groups]), status=200)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        logging.error("An error occurred while fetching user member groups: %s", e, exc_info=True)
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/user-groups/<group_id>', methods=['PUT'])
 def update_user_group(group_id: str):
@@ -277,7 +279,8 @@ def update_user_group(group_id: str):
     except SessionNotFoundError as e:
         return Response(response=str(e), status=404)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        logging.error("An error occurred while updating user group: %s", e, exc_info=True)
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/resources/<resource_id>', methods=['POST'])
 def create_resource(resource_id: str):
@@ -296,7 +299,8 @@ def create_resource(resource_id: str):
     except CosmosConflictError as e:
         return Response(response=str(e), status=409)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        logging.error("An error occurred while creating resource: %s", e, exc_info=True)
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/resources/<resource_id>', methods=['GET'])
 def get_resource(resource_id: str):


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/49](https://github.com/arpitjain099/openai/security/code-scanning/49)

To fix the problem, we need to ensure that detailed exception information, including stack traces, is not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by using Python's `logging` module to log the exception details and returning a generic error message in the HTTP response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
