### PR TITLE
Fix code scanning alert no. 9: Reflected server-side cross-site scripting

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -11,6 +11,7 @@ from data.managers.permissions.manager import PermissionsManager
 from data.managers.entities.api.manager import EntitiesManager
 from datetime import datetime
 from flask import Flask, Response, request
+import html
 from typing import List, Set
 import logging
 # initialize config
@@ -196,7 +197,8 @@ def get_user_profile(user_id: str):
     try:
         user_profile = entities_manager.get_user_profile(user_id)
         if user_profile is None:
-            return Response(response=f"User profile with user_id {user_id} not found.", status=404)
+            escaped_user_id = html.escape(user_id)
+            return Response(response=f"User profile with user_id {escaped_user_id} not found.", status=404)
         else:
             return Response(response=json.dumps(user_profile.to_item()), status=200)
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/9](https://github.com/arpitjain099/openai/security/code-scanning/9)

To fix the reflected server-side cross-site scripting vulnerability, we need to escape the `user_id` before including it in the response message. This can be done using the `html.escape()` function from the `html` module in Python, which safely escapes special characters in the string to their corresponding HTML entities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
