### PR TITLE
Fix code scanning alert no. 63: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -361,7 +361,8 @@ def create_access_rule(rule_id: str):
         logging.error(f"Validation error in create_access_rule: {e}", exc_info=True)
         return Response(response="Invalid input provided.", status=400)
     except CosmosConflictError as e:
-        return Response(response=str(e), status=409)
+        logging.error(f"Cosmos conflict error in create_access_rule: {e}", exc_info=True)
+        return Response(response="A conflict occurred while processing your request.", status=409)
     except Exception as e:
         logging.error(f"Error in create_access_rule: {e}", exc_info=True)
         return Response(response="An internal error has occurred.", status=500)


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/63](https://github.com/arpitjain099/openai/security/code-scanning/63)

To fix the problem, we need to replace the direct return of `str(e)` with a more generic error message. This ensures that no sensitive information is exposed to the end user while still logging the detailed error for debugging purposes.

- Replace the line returning `str(e)` with a generic error message.
- Ensure that the detailed error is logged using `logging.error`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
