### PR TITLE
Fix code scanning alert no. 51: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -297,7 +297,8 @@ def create_resource(resource_id: str):
         resource = entities_manager.create_resource(resource_id, resource_type)
         return Response(response=json.dumps(resource.to_item()), status=201)
     except (TypeError, NullValueError, MissingPropertyError) as e:
-        return Response(response=str(e), status=400)
+        logging.error("An error occurred while creating resource: %s", e, exc_info=True)
+        return Response(response="An internal error has occurred.", status=400)
     except CosmosConflictError as e:
         return Response(response=str(e), status=409)
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/51](https://github.com/arpitjain099/openai/security/code-scanning/51)

To fix the problem, we need to ensure that detailed exception information is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach maintains the ability to debug issues using server logs while protecting sensitive information from being exposed.

- Modify the `except` block on line 299 to log the error and return a generic error message.
- Ensure that the logging captures the full stack trace for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
