### PR TITLE
Fix code scanning alert no. 64: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -279,7 +279,8 @@ def update_user_group(group_id: str):
     except (TypeError, NullValueError, MissingPropertyError, ValueError) as e:
         return Response(response=str(e), status=400)
     except SessionNotFoundError as e:
-        return Response(response=str(e), status=404)
+        logging.error("Session not found: %s", e, exc_info=True)
+        return Response(response="Session not found.", status=404)
     except Exception as e:
         logging.error("An error occurred while updating user group: %s", e, exc_info=True)
         return Response(response="An internal error has occurred.", status=500)


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/64](https://github.com/arpitjain099/openai/security/code-scanning/64)

To fix the problem, we need to ensure that the exception message is not directly exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach maintains the ability to debug issues using server logs while preventing potential attackers from gaining insights into the application's internal structure.

- Modify the code on line 282 to log the exception and return a generic error message.
- Ensure that the logging includes the stack trace for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
