### PR TITLE
Fix code scanning alert no. 8: Reflected server-side cross-site scripting

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -85,8 +85,8 @@ def get_chat_session(user_id: str, conversation_id: str):
         properties = logger.get_updated_properties(addl_dim)
 
         if session is None:
-            logger.info(f"get-chat-session: session with conversation_id {conversation_id} not found", extra=properties)
-            return Response(response=f"Chat session with conversation_id {conversation_id} not found.", status=404)
+            logger.info(f"get-chat-session: session with conversation_id {html.escape(conversation_id)} not found", extra=properties)
+            return Response(response=f"Chat session with conversation_id {html.escape(conversation_id)} not found.", status=404)
         else:
             logger.info("get-chat-session: session found", extra=properties)
             return Response(response=json.dumps(session.to_item()), status=200)


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/8](https://github.com/arpitjain099/openai/security/code-scanning/8)

To fix the reflected server-side cross-site scripting vulnerability, we need to escape the `conversation_id` before including it in the HTTP response. The `html.escape()` function from the `html` module in Python can be used for this purpose. This function will convert special characters to HTML-safe sequences, preventing the execution of any embedded scripts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
