### PR TITLE
Fix code scanning alert no. 10: Reflected server-side cross-site scripting

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -242,7 +242,8 @@ def get_user_group(group_id: str):
     try:
         user_group = entities_manager.get_user_group(group_id)
         if user_group is None:
-            return Response(response=f"User group with group_id {group_id} not found.", status=404)
+            escaped_group_id = html.escape(group_id)
+            return Response(response=f"User group with group_id {escaped_group_id} not found.", status=404)
         else:
             return Response(response=json.dumps(user_group.to_item()), status=200)
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/10](https://github.com/arpitjain099/openai/security/code-scanning/10)

To fix the reflected XSS vulnerability, we need to escape the `group_id` parameter before including it in the response. This can be done using the `html.escape()` function from the `html` module, which is already imported in the file. This ensures that any special characters in the `group_id` are properly escaped, preventing the injection of malicious scripts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
