### PR TITLE
Fix code scanning alert no. 11: Reflected server-side cross-site scripting

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -254,7 +254,7 @@ def get_user_member_groups(user_id: str):
     try:
         user_groups = entities_manager.get_user_member_groups(user_id)
         if user_groups is None:
-            return Response(response=f"User with user_id {user_id} not found.", status=404)
+            return Response(response=f"User with user_id {html.escape(user_id)} not found.", status=404)
         else:
             return Response(response=json.dumps([user_group.to_item_no_users() for user_group in user_groups]), status=200)
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/11](https://github.com/arpitjain099/openai/security/code-scanning/11)

To fix the reflected server-side cross-site scripting vulnerability, we need to escape the `user_id` before including it in the response. This can be done using the `html.escape()` function from the `html` module, which ensures that any special characters in the `user_id` are properly escaped, preventing the execution of any embedded scripts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
