### PR TITLE
Fix code scanning alert no. 12: Reflected server-side cross-site scripting

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -310,7 +310,7 @@ def get_resource(resource_id: str):
     try:
         resource = entities_manager.get_resource(resource_id)
         if resource is None:
-            return Response(response=f"Resource with resource_id {resource_id} not found.", status=404)
+            return Response(response=f"Resource with resource_id {html.escape(resource_id)} not found.", status=404)
         else:
             return Response(response=json.dumps(resource.to_item()), status=200)
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/12](https://github.com/arpitjain099/openai/security/code-scanning/12)

To fix the reflected server-side cross-site scripting vulnerability, we need to escape the user-provided `resource_id` before including it in the response. The `html.escape()` function from the `html` module in Python can be used to safely escape any special characters in the `resource_id` that could be interpreted as HTML.

- **General fix:** Escape the `resource_id` using `html.escape()` before including it in the response message.
- **Detailed fix:** Modify the line where the `resource_id` is used in the response message to use `html.escape(resource_id)`.
- **Specific changes:** Update line 313 in the file `End_to_end_Solutions/AOAISearchDemo/app/data/app.py` to use `html.escape(resource_id)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
