### PR TITLE
Fix code scanning alert no. 14: Reflected server-side cross-site scripting

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -373,7 +373,7 @@ def get_access_rule(rule_id: str):
     try:
         access_rule = permissions_manager.get_access_rule(rule_id)
         if access_rule is None:
-            return Response(response=f"Access rule with rule_id {rule_id} not found.", status=404)
+            return Response(response=f"Access rule with rule_id {html.escape(rule_id)} not found.", status=404)
         else:
             return Response(response=json.dumps(access_rule.to_item()), status=200)
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/14](https://github.com/arpitjain099/openai/security/code-scanning/14)

To fix the reflected server-side cross-site scripting vulnerability, we need to escape the `rule_id` before including it in the response message. The `html.escape()` function from the standard library can be used to safely escape any special HTML characters in the `rule_id`.

- **General Fix:** Escape the `rule_id` before including it in the response message to prevent XSS.
- **Detailed Fix:** Modify the line where the `rule_id` is included in the response message to use `html.escape(rule_id)`.
- **Specific Changes:** Update line 376 in the file `End_to_end_Solutions/AOAISearchDemo/app/data/app.py` to use `html.escape(rule_id)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
