### PR TITLE
Fix code scanning alert no. 32: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -114,7 +114,7 @@ def check_chat_session(user_id: str, conversation_id: str):
             return Response(response="true", status=200)
     except Exception as e:
         logger.exception(f"check-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=500)
+        return Response(response="An internal error has occurred.", status=500)
 
 @app.route('/chat-sessions/<user_id>/<conversation_id>', methods=['PUT'])
 def update_chat_session(user_id: str, conversation_id: str):


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/32](https://github.com/arpitjain099/openai/security/code-scanning/32)

To fix the problem, we need to replace the direct return of the exception message with a generic error message. The detailed exception information should be logged on the server for debugging purposes. This approach ensures that sensitive information is not exposed to the end user while still allowing developers to diagnose issues.

- Replace `return Response(response=str(e), status=500)` with `return Response(response="An internal error has occurred.", status=500)` in the `check_chat_session` function.
- Ensure that the detailed exception information is logged using `logger.exception`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
