### PR TITLE
Fix code scanning alert no. 31: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -68,7 +68,7 @@ def create_chat_session(user_id: str, conversation_id: str):
         return Response(response=str(e), status=409)
     except Exception as e:
         logger.exception(f"create-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=500)
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/chat-sessions/<user_id>/<conversation_id>', methods=['GET'])
 def get_chat_session(user_id: str, conversation_id: str):
@@ -92,7 +92,7 @@ def get_chat_session(user_id: str, conversation_id: str):
             return Response(response=json.dumps(session.to_item()), status=200)
     except Exception as e:
         logger.exception(f"get-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=500)
+        return Response(response="An internal error has occurred.", status=500)
 
 @app.route('/check-chat-session/<user_id>/<conversation_id>', methods=['GET'])
 def check_chat_session(user_id: str, conversation_id: str):
@@ -114,7 +114,7 @@ def check_chat_session(user_id: str, conversation_id: str):
             return Response(response="true", status=200)
     except Exception as e:
         logger.exception(f"check-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=500)
+        return Response(response="An internal error has occurred.", status=500)
 
 @app.route('/chat-sessions/<user_id>/<conversation_id>', methods=['PUT'])
 def update_chat_session(user_id: str, conversation_id: str):


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/31](https://github.com/arpitjain099/openai/security/code-scanning/31)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to return a generic error message while logging the detailed error message.

**Steps to fix:**
1. Modify the exception handling code in the `create_chat_session`, `get_chat_session`, and `check_chat_session` functions to return a generic error message.
2. Ensure that the detailed error message is logged using the existing logger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
