### PR TITLE
Fix code scanning alert no. 29: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -62,13 +62,13 @@ def create_chat_session(user_id: str, conversation_id: str):
         return Response(response=json.dumps(session.to_item()), status=201)
     except (TypeError, NullValueError, MissingPropertyError) as e:
         logger.exception(f"create-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=400)
+        return Response(response="Invalid input provided.", status=400)
     except CosmosConflictError as e:
         logger.exception(f"create-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=409)
+        return Response(response="Conflict occurred while creating chat session.", status=409)
     except Exception as e:
         logger.exception(f"create-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=500)
+        return Response(response="An internal error has occurred.", status=500)
     
 @app.route('/chat-sessions/<user_id>/<conversation_id>', methods=['GET'])
 def get_chat_session(user_id: str, conversation_id: str):
@@ -92,7 +92,7 @@ def get_chat_session(user_id: str, conversation_id: str):
             return Response(response=json.dumps(session.to_item()), status=200)
     except Exception as e:
         logger.exception(f"get-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=500)
+        return Response(response="An internal error has occurred.", status=500)
 
 @app.route('/check-chat-session/<user_id>/<conversation_id>', methods=['GET'])
 def check_chat_session(user_id: str, conversation_id: str):


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/29](https://github.com/arpitjain099/openai/security/code-scanning/29)

To fix the problem, we need to modify the code to ensure that detailed exception messages are not returned to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by updating the `except` blocks to return a generic message while still logging the detailed exception.

1. Update the `except` blocks to return a generic error message.
2. Ensure that the detailed exception is logged using `logger.exception`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
