### PR TITLE
Fix code scanning alert no. 35: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -148,13 +148,13 @@ def update_chat_session(user_id: str, conversation_id: str):
         return Response(response=json.dumps(session.to_item()), status=200)
     except (TypeError, NullValueError, MissingPropertyError, ValueError) as e:
         logger.exception(f"update-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=400)
+        return Response(response="An error occurred while processing your request.", status=400)
     except SessionNotFoundError as e:
         logger.exception(f"update-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=404)
+        return Response(response="Chat session not found.", status=404)
     except Exception as e:
         logger.exception(f"update-chat-session: error: {e} ", extra=properties)
-        return Response(response=str(e), status=500)
+        return Response(response="An internal server error occurred.", status=500)
     
 @app.route('/chat-sessions/<user_id>/<conversation_id>', methods=['DELETE'])
 def clear_chat_session(user_id: str, conversation_id: str):
@@ -162,9 +162,10 @@ def clear_chat_session(user_id: str, conversation_id: str):
         chat_manager.clear_chat_session(user_id, conversation_id)
         return Response(status=200)
     except SessionNotFoundError as e:
-        return Response(response=str(e), status=404)
+        return Response(response="Chat session not found.", status=404)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        logger.exception(f"clear-chat-session: error: {e}")
+        return Response(response="An internal server error occurred.", status=500)
     
 @app.route('/user-profiles/<user_id>', methods=['POST'])
 def create_user_profile(user_id: str):
@@ -185,11 +186,12 @@ def create_user_profile(user_id: str):
         user_profile = entities_manager.create_user_profile(user_id, user_name, description, sample_questions)
         return Response(response=json.dumps(user_profile.to_item()), status=201)
     except (TypeError, NullValueError, MissingPropertyError) as e:
-        return Response(response=str(e), status=400)
+        return Response(response="Invalid request data.", status=400)
     except CosmosConflictError as e:
-        return Response(response=str(e), status=409)
+        return Response(response="Conflict occurred while creating user profile.", status=409)
     except Exception as e:
-        return Response(response=str(e), status=500)
+        logger.exception(f"create-user-profile: error: {e}")
+        return Response(response="An internal server error occurred.", status=500)
     
 @app.route('/user-profiles/<user_id>', methods=['GET'])
 def get_user_profile(user_id: str):


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/35](https://github.com/arpitjain099/openai/security/code-scanning/35)

To fix the problem, we need to ensure that detailed exception messages are not returned to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to log the exception and return a generic message.

1. Modify the exception handling blocks to log the detailed error message.
2. Return a generic error message to the user instead of the exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
