### PR TITLE
Fix code scanning alert no. 18: Full server-side request forgery

### DIFF
--- a/End_to_end_Solutions/InsightsGenerator/insights_generator/core/OAI_client.py
+++ b/End_to_end_Solutions/InsightsGenerator/insights_generator/core/OAI_client.py
@@ -5,8 +5,11 @@ import pdb
 import tiktoken
 
 def make_prompt_request(prompt, max_tokens = 2048, timeout = 4):
-    #url = "https://api.openai.com/v1/embeddings"
+    # Whitelist of allowed URLs
+    allowed_urls = ["https://api.openai.com/v1/embeddings", "https://another-trusted-url.com"]
     url = os.getenv("AOAI_ENDPOINT")
+    if url not in allowed_urls:
+        raise ValueError("The provided URL is not allowed.")
     key = os.getenv("AOAI_KEY")
                   
     payload_dict = {"prompt": prompt,


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/18](https://github.com/arpitjain099/openai/security/code-scanning/18)

To fix the SSRF vulnerability, we need to ensure that the `url` derived from the environment variable is validated against a list of known, trusted URLs. This can be achieved by maintaining a whitelist of allowed URLs and checking the `url` against this list before making the request.

1. Create a list of authorized URLs.
2. Validate the `url` against this list.
3. If the `url` is not in the list, raise an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
