### PR TITLE
Fix code scanning alert no. 66: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -281,7 +281,8 @@ def update_user_group(group_id: str):
         user_group = entities_manager.add_users_to_user_group(group_id, new_users)
         return Response(response=json.dumps(user_group.to_item()), status=200)
     except (TypeError, NullValueError, MissingPropertyError, ValueError) as e:
-        return Response(response=str(e), status=400)
+        logging.error("An error occurred while updating user group: %s", e, exc_info=True)
+        return Response(response="An internal error has occurred.", status=400)
     except SessionNotFoundError as e:
         logging.error("Session not found: %s", e, exc_info=True)
         return Response(response="Session not found.", status=404)


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/66](https://github.com/arpitjain099/openai/security/code-scanning/66)

To fix the problem, we should avoid returning the exception message directly to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the logs.

- Modify the `except` block starting at line 283 to log the error and return a generic error message.
- Ensure that the logging captures the exception details for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
