### PR TITLE
Fix code scanning alert no. 24: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/backend/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/backend/app.py
@@ -340,7 +340,7 @@ def chat():
         return jsonify(response.to_item()), 400
     except Exception as e:
         logger.exception(f"Exception in /chat: {e}", extra=properties)
-        response = ChatResponse(answer=Answer(), error=str(e), show_retry=True)
+        response = ChatResponse(answer=Answer(), error="An internal error has occurred.", show_retry=True)
         return jsonify(response.to_item()), 500
 
 
@@ -352,7 +352,7 @@ def get_all_user_profiles():
         return jsonify(user_profiles_dict)
     except Exception as e:
         logger.exception(f"Exception in /user-profiles: {e}")
-        return jsonify({"error": "An internal error has occurred!"}), 500
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/chat-sessions/<user_id>/<conversation_id>", methods=["DELETE"])
@@ -369,7 +369,7 @@ def clear_chat_session(user_id: str, conversation_id: str):
         logger.exception(
             f"Exception in /chat-sessions/<user_id>/<conversation_id>: {e}"
         )
-        return jsonify({"error": "An internal error has occurred!"}), 500
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 @app.route("/search-settings", methods=["GET"])
@@ -391,7 +391,7 @@ def get_search_settings():
         return jsonify(search_settings.to_item())
     except Exception as e:
         logger.exception(f"Exception in /search-settings: {e}")
-        return jsonify({"error": "An internal error has occurred!"}), 500
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/24](https://github.com/arpitjain099/openai/security/code-scanning/24)

To fix the problem, we need to ensure that detailed exception messages are not returned to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This involves modifying the exception handling blocks to replace the detailed error message with a generic one in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
