### PR TITLE
Fix code scanning alert no. 67: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -309,7 +309,8 @@ def create_resource(resource_id: str):
         logging.error("An error occurred while creating resource: %s", e, exc_info=True)
         return Response(response="An internal error has occurred.", status=400)
     except CosmosConflictError as e:
-        return Response(response=str(e), status=409)
+        logging.error("A conflict occurred while creating resource: %s", e, exc_info=True)
+        return Response(response="A conflict occurred while creating the resource.", status=409)
     except Exception as e:
         logging.error("An error occurred while creating resource: %s", e, exc_info=True)
         return Response(response="An internal error has occurred.", status=500)


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/67](https://github.com/arpitjain099/openai/security/code-scanning/67)

To fix the problem, we need to ensure that the exception message from `CosmosConflictError` is not directly exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach aligns with the other exception handling blocks in the file.

**Steps to fix:**
1. Modify the exception handling block for `CosmosConflictError` to log the error message.
2. Return a generic error message in the HTTP response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
