### PR TITLE
Fix code scanning alert no. 65: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -238,7 +238,8 @@ def create_user_group(group_id: str):
     except (TypeError, NullValueError, MissingPropertyError) as e:
         return Response(response=str(e), status=400)
     except CosmosConflictError as e:
-        return Response(response=str(e), status=409)
+        logging.error("A conflict error occurred while creating user group: %s", e, exc_info=True)
+        return Response(response="A conflict error has occurred.", status=409)
     except Exception as e:
         logging.error("An error occurred while creating user group: %s", e, exc_info=True)
         return Response(response="An internal error has occurred.", status=500)


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/65](https://github.com/arpitjain099/openai/security/code-scanning/65)

To fix the problem, we need to ensure that the exception message from `CosmosConflictError` is not directly exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This approach maintains the security of the application by preventing the exposure of potentially sensitive information.

- Modify the exception handling block for `CosmosConflictError` to log the error message and return a generic error message to the user.
- Ensure that the logging captures the detailed error information for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
