### PR TITLE
Fix code scanning alert no. 38: Information exposure through an exception

### DIFF
--- a/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
+++ b/End_to_end_Solutions/AOAISearchDemo/app/data/app.py
@@ -236,7 +236,8 @@ def create_user_group(group_id: str):
         user_group = entities_manager.create_user_group(group_id, group_name, users)
         return Response(response=json.dumps(user_group.to_item()), status=201)
     except (TypeError, NullValueError, MissingPropertyError) as e:
-        return Response(response=str(e), status=400)
+        logging.error("A validation error occurred: %s", e, exc_info=True)
+        return Response(response="A validation error has occurred.", status=400)
     except CosmosConflictError as e:
         return Response(response=str(e), status=409)
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/arpitjain099/openai/security/code-scanning/38](https://github.com/arpitjain099/openai/security/code-scanning/38)

To fix the problem, we need to ensure that the exception message is not directly returned to the user. Instead, we should log the exception details on the server and return a generic error message to the user. This approach is consistent with the other exception handling blocks in the same file.

- Modify the exception handling block starting at line 238 to log the error and return a generic error message.
- Ensure that the logging captures the exception details for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
